### PR TITLE
chore: Missing `\c` command

### DIFF
--- a/content/tutorials/how-to-install-misskey-in-ubuntu-22-04-manual-without-docker/index.md
+++ b/content/tutorials/how-to-install-misskey-in-ubuntu-22-04-manual-without-docker/index.md
@@ -136,6 +136,7 @@ sudo -u postgres psql
 CREATE DATABASE <your_db_name> WITH ENCODING = 'UTF8';
 CREATE USER <your_misskey_db_user> WITH ENCRYPTED PASSWORD '<YOUR_PASSWORD>';
 GRANT ALL PRIVILEGES ON DATABASE <your_db_name> TO <your_misskey_db_user>;
+\c <your_db_name>
 GRANT ALL ON SCHEMA public TO <your_misskey_db_user>;
 \q
 ```


### PR DESCRIPTION
Missing `\c` command before executing `GRANT ALL ON SCHEMA public TO ...`