### PR TITLE
fix: Only run deploy action on main repo

### DIFF
--- a/.github/workflows/deploy-to-vps.yaml
+++ b/.github/workflows/deploy-to-vps.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'ditatompel'
     environment: production
     permissions:
       contents: read


### PR DESCRIPTION
The previous deploy workflow is executed to all forks.